### PR TITLE
* Dont install the current addons in dependency check

### DIFF
--- a/src/dependencyCheck.js
+++ b/src/dependencyCheck.js
@@ -179,21 +179,6 @@ function run() {
 		addons.forEach(function (addon) {
 			installer.install(addon, null, f.wait());
 		});
-
-		f(package);
-		fs.readdir(common.paths.root('addons'), f());
-	}, function (package, addons) {
-		// check version for all optional addons if they're installed
-		addons.forEach(function (addon) {
-			var onFinish = f();
-			addonManager.install(addon, {}, function (err, res) {
-				if (err && (err.NOT_INSTALLED || err.UNKNOWN_ADDON)) {
-					onFinish(); // don't worry about these errors
-				} else {
-					onFinish(err); // forward unexpected errors
-				}
-			});
-		});
 	}).error(function (err) {
 		logger.error("Error:");
 		console.log(err);


### PR DESCRIPTION
Is this the right repo?

Currently we try and reinstall all the addons but that gives us an error that it's already installed so let's just not try install it again.
