### PR TITLE
Use the last name folder as the name of the project.

### DIFF
--- a/src/init/index.js
+++ b/src/init/index.js
@@ -97,7 +97,6 @@ var initProject = function(template, dest){
 };
 
 var projectName = function(dest) {
-  var folders = dest.split(/\//);
-  return folders[folders.length - 1];
+  return path.basename(dest);
 };
 


### PR DESCRIPTION
When I've tried to create a new project using `basil init ./projects/hello-world` I got in the manifest file shortName and title as the destination names. Simulator didn't work for me in this case.

I've decided to use for the project name the latest folder name on init process instead of destination.

What do you think?
