### PR TITLE
Use the last name folder as the name of the project.

### DIFF
--- a/src/init/index.js
+++ b/src/init/index.js
@@ -84,7 +84,7 @@ var initProject = function(template, dest){
 	var man = JSON.parse(fs.readFileSync(manPath).toString());
 	man.appID = createUUID();
 
-  var project = projectName(dest);
+  var project = path.basename(dest);
 	man.shortName = project;
 	man.title = project;
 
@@ -94,9 +94,5 @@ var initProject = function(template, dest){
 
 	//now register the new project
 	register(newLocation);
-};
-
-var projectName = function(dest) {
-  return path.basename(dest);
 };
 


### PR DESCRIPTION
When I've tried to create a new project using basil init ./projects/hello-world I got in the manifest file shortName and title as the destination names. Simulator didn't work for me in this case.

I've decided to use for the project name the latest folder name on init process instead of destination.
