### PR TITLE
Reset stdin after src/analysis.js is run. Fixes gameclosure/devkit#42

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -97,6 +97,10 @@ node src/dependencyCheck.js
 if [[ "$1" != "--silent" ]]; then
 	node src/analytics.js
 
+	# Work around a known issue with older versions of node, where stdin is left in non-blocking mode
+	# Reset stdin handle
+	exec 0<"/dev/stdin"
+
 	echo 
 
 	CURRENT_BASIL_PATH=$(which basil)


### PR DESCRIPTION
I confirmed issue gameclosure/devkit#42 with node v0.10.4 on XUbuntu 12.04.

This commit resets stdin after src/analytics.js is run, ensuring stdin is sane for the subsequent 'read' command in install.sh.

node.js sets process.stdin to non-blocking mode when it is first evaluated. There was an issue raised to set this back to blocking mode on exit (https://github.com/joyent/node/issues/3994), however testing with v0.11.2-pre showed this to still be a problem.

I don't currently have a Windows setup of devkit, so have NOT tested this under cygwin.

Regards,
  Stewart Platt.
