### PR TITLE
Improving the dynamics of the "system-wide installation" query

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -74,7 +74,11 @@ SYSTEM_WIDE_INSTALL=false
 
 if [[ $is_silent != 1 ]]; then
 	if [[ `uname` != MINGW32* ]]; then
-		read -p "Would you like to install the Game Closure DevKit system-wide in /usr/local/bin [Y/n] ?" -n 1 -r
+		read -p "Would you like to install the Game Closure DevKit system-wide in /usr/local/bin [Y/n] ?" -r
+		while [[ ($REPLY != 'y') && ($REPLY != 'Y') && ($REPLY != 'n') && ($REPLY != 'N') ]]; do
+			read -p "Invalid option \"$REPLY\". Please type either Y or n:" -r
+		done
+
 		echo
 
 		if [[ ($REPLY != 'n') && ($REPLY != 'N') ]]; then


### PR DESCRIPTION
Here I propose two changes to how the "system-wide installation" query should work.
First: I presume most users are familiar with pressing [enter] after a [Y/n] query on the terminal. By limiting the number of chars processed by the read command (and proceeding with the installation after the first key was pressed), anything the user presses afterwards will be evaluated by the succeeding "read" commands. In my case, I typed [enter] after the y, and the "By default basil will send anonymous usage and crash (...)" query received this keystroke. I personally didn't mind, but it might not be the choice of another user.

Second change: the query should be strict about only accepting "y" or "n", repeating itself should the user mistype his choice.
