### PR TITLE
Link to windows setup doesn't exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ global `node_modules` folder.
 Follow the instructions on [the project wiki](https://github.com/gameclosure/devkit2/wiki/Install-Instructions---Linux)
 
 ### Windows
-Follow the instructions on [the project wiki](https://github.com/gameclosure/devkit2/wiki/Install-Instructions---Windows)
+Follow the instructions on [the project wiki](https://github.com/gameclosure/devkit/wiki/Install-Instructions---Windows)
 
 
 


### PR DESCRIPTION
The page at the end of the original Windows installation instructions (https://github.com/gameclosure/devkit2/wiki/Install-Instructions---Windows) needs to be fixed or made. Until then, suggest rewinding/updating the current link to this one that works.