### PR TITLE
resource editor module

### DIFF
--- a/modules/resource-editor/package.json
+++ b/modules/resource-editor/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "resource-editor",
+  "author": "Martin Hunt",
+  "version": "0.0.1",
+  "devkit": {
+    "extensions": {
+      "standaloneUI": {
+        "ui": {
+          "src": "ui",
+          "html5History": true
+        }
+      }
+    },
+    "pluginBuilder": {
+      "generic": [
+        {
+          "src": "ui"
+        }
+      ]
+    }
+  },
+  "dependencies": {
+    "bluebird": "^3.0.6",
+    "classnames": "^2.2.1",
+    "history": "=1.13",
+    "http-fs": "https://github.com/weebygames/http-fs",
+    "qrcode.react": "^0.5.2",
+    "react": "^0.14.3",
+    "react-dom": "^0.14.3",
+    "react-file-drop": "^0.1.7",
+    "react-http-fs-file-tree": "https://github.com/weebygames/react-http-fs-file-tree#v0.0.1",
+    "react-router": "^1.0.0"
+  },
+  "devDependencies": {
+    "babel-preset-react": "^6.3.13",
+    "babel-preset-stage-0": "^6.3.13",
+    "babelify": "^7.2.0"
+  }
+}

--- a/modules/resource-editor/ui/components/FileInspector.js
+++ b/modules/resource-editor/ui/components/FileInspector.js
@@ -1,0 +1,32 @@
+import path from 'path';
+import React from 'react';
+
+import FilePreview from './FilePreview';
+
+export default class FileInspector extends React.Component {
+  constructor() {
+    super();
+
+    this.actions = [
+      {name: 'delete'},
+      {name: 'move'},
+      {name: 'copy'}
+    ];
+
+    this.state = {};
+  }
+
+  render() {
+    let file = this.props.file;
+
+    return <div className="FileInspector">
+      {file && <div>
+        <FilePreview cwd={path.join(this.props.fs.MOUNT_POINT, this.props.fs.CWD)} file={file} />
+        <div className="filePath">{file.path}</div>
+        {this.actions.map(action => <div className="action" key={action.name}>
+          {action.name}
+        </div>)}
+      </div>}
+    </div>;
+  }
+}

--- a/modules/resource-editor/ui/components/FilePreview.js
+++ b/modules/resource-editor/ui/components/FilePreview.js
@@ -1,0 +1,61 @@
+import path from 'path';
+import React from 'react';
+
+import {imageLoader} from '../util/ImageLoader';
+import IMAGE_TYPES from '../util/ImageTypes';
+
+export default class FilePreview extends React.Component {
+  constructor() {
+    super();
+    this.state = {};
+  }
+
+  componentDidMount() {
+    this.updateProps(this.props);
+  }
+
+  componentWillReceiveProps(props) {
+    this.updateProps(props);
+  }
+
+  updateProps(props) {
+    let file = props.file;
+    if (file.path !== this._path) {
+      this._path = file.path;
+
+      let src = path.extname(file.path) in IMAGE_TYPES
+        ? path.join(this.props.cwd, file.path)
+        : '';
+
+      this.setState({src});
+    }
+  }
+
+  handleClick = (event) => {
+    this.props.onClick && this.props.onClick(this.props.file, event);
+  }
+
+  refresh() {
+    let src = this.state.src;
+    imageLoader.load(src)
+      .then(({width, height}) => {
+        let thumbnail = this.refs.thumbnail;
+        let isContain = width > thumbnail.offsetWidth
+                     || height > thumbnail.offsetHeight;
+        thumbnail.style.backgroundSize = isContain ? 'contain' : 'initial';
+      });
+  }
+
+  render() {
+    let file = this.props.file;
+    let src = this.state.src || '';
+    if (src) { this.refresh(); }
+
+    return <div className="FilePreview" onClick={this.handleClick}>
+        <div className="thumbnailWrapper">
+          <div ref="thumbnail" className="thumbnail" style={{backgroundImage: 'url("' + src.replace(/"/g, '\\"') + '")'}} />
+        </div>
+        <label>{file.name}</label>
+      </div>;
+  }
+}

--- a/modules/resource-editor/ui/components/FolderViewer.js
+++ b/modules/resource-editor/ui/components/FolderViewer.js
@@ -1,0 +1,24 @@
+import path from 'path';
+import React from 'react';
+import classnames from 'classnames';
+import FilePreview from './FilePreview';
+
+export default class extends React.Component {
+
+  componentDidReceiveProps(props) {
+    if (props.folder !== this._folder) {
+      this._folder = props.folder;
+    }
+  }
+
+  render() {
+    var files = this.props.files;
+    return <div className={classnames("FolderViewer", this.props.className)}>
+      {files && files.filter(file => !file.isDirectory).map(file => <FilePreview
+          key={file.path}
+          cwd={path.join(this.props.fs.MOUNT_POINT, this.props.fs.CWD)}
+          file={file}
+          onClick={this.props.onFile} />)}
+    </div>;
+  }
+}

--- a/modules/resource-editor/ui/components/PathCrumbs.js
+++ b/modules/resource-editor/ui/components/PathCrumbs.js
@@ -1,0 +1,22 @@
+import React from 'react';
+
+export default class PathCrumbs extends React.Component {
+  constructor() {
+    super();
+    this.state = {};
+  }
+
+  render() {
+    var folder = this.props.folder;
+    var crumbs = [];
+    if (folder) {
+      crumbs = folder.path.split('/').filter(a => a);
+    }
+
+    return <div className="PathCrumbs">
+      {crumbs.map((crumb, index) => <div className="crumb" key={index}>
+          {crumb}
+        </div>)}
+    </div>;
+  }
+}

--- a/modules/resource-editor/ui/css/index.styl
+++ b/modules/resource-editor/ui/css/index.styl
@@ -1,0 +1,97 @@
+html, body
+  padding 0
+  margin 0
+  width 100%
+  height 100%
+  overflow hidden
+
+#main
+  width 100%
+  height 100%
+  background #EEE
+  color #444
+  font-family 'Helvetica Neue', Helvetica, sans-serif
+  font-weight 200
+  font-size 80%
+
+.flex
+  flex 1
+  flex-shrink 0
+
+.row
+  display flex
+  flex-direction row
+  width 100%
+
+.column
+  display flex
+  width 100%
+  flex-direction column
+
+.full-height
+  position relative
+
+  > *
+    position absolute
+    top 0
+    bottom 0
+
+.MainContainer
+  align-items stretch
+  height 100%
+
+.FileTree
+  border-right 1px solid #CCC
+  width 250px
+  flex-shrink 0
+  overflow auto
+
+.FileNode
+  .label
+    padding 10px 5px
+    height 20px
+
+    .file-icon
+      margin-right 5px
+
+.FolderViewer
+  overflow auto
+  padding 5px
+
+.FilePreview
+  width 202px
+  height 250px
+  margin-right 5px
+  display inline-block
+
+  .thumbnailWrapper
+    padding 10px
+    background white
+    border 1px solid #CCC
+
+  .thumbnail
+    width 180px
+    height 180px
+    background-size contain
+    background-position center
+    background-repeat no-repeat
+
+  label
+    display block
+    margin-top 5px
+    text-align center
+    text-overflow ellipsis
+    overflow hidden
+
+.PathCrumbs
+  border-bottom 1px solid #CCC
+
+  .crumb
+    display inline-block
+    line-height 20px
+    border-right 1px solid #CCC
+    padding 5px 10px
+
+.FileInspector
+  border-left 1px solid #CCC
+  padding 5px

--- a/modules/resource-editor/ui/index.html
+++ b/modules/resource-editor/ui/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <link rel="stylesheet" href="/static/fa/font-awesome.css">
+  <link rel="stylesheet" href="index.css">
+
+  <script src="/socket.io/socket.io.js"></script>
+  <script src="/RemoteAPI.js"></script>
+</head>
+<body>
+
+  <div id="main"></div>
+  <!-- build:js -->
+  <script src="src/build.js"></script>
+  <!-- endbuild -->
+
+</body>
+</html>

--- a/modules/resource-editor/ui/index.js
+++ b/modules/resource-editor/ui/index.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import FileTree from 'react-http-fs-file-tree';
+import remoteFS from 'http-fs/src/clients/fs';
+import FolderViewer from './components/FolderViewer';
+import PathCrumbs from './components/PathCrumbs';
+import FileInspector from './components/FileInspector';
+
+export default class ResourceEditor extends React.Component {
+  constructor() {
+    super();
+
+    this.state = {};
+
+    remoteFS('../../../../http-fs/', {cwd: 'resources'})
+      .then(fs => this.setState({fs}));
+  }
+
+  handleFolder = (folder) => {
+    this.setState({folder});
+  }
+
+  handleFile = (file) => {
+    this.setState({file});
+  }
+
+  handleFilesLoaded = (folder, isSelected, subfiles) => {
+    if (folder.path === this.state.folder.path) {
+      this.setState({files: subfiles});
+    }
+  }
+
+  render() {
+    return <div className="MainContainer row">
+        <FileTree
+            fs={this.state.fs}
+            onlyFolders={true}
+            name="resources"
+            onFile={this.handleFolder}
+            onFilesLoaded={this.handleFilesLoaded}
+          />
+        <div className="column">
+          <PathCrumbs folder={this.state.folder} />
+          <div className="full-height flex">
+            <div className="row">
+              <FolderViewer
+                  className="flex"
+                  fs={this.state.fs}
+                  folder={this.state.folder}
+                  files={this.state.files}
+                  onFile={this.handleFile}
+                />
+              <FileInspector
+                  fs={this.state.fs}
+                  file={this.state.file} />
+            </div>
+          </div>
+        </div>
+      </div>;
+  }
+}
+
+ReactDOM.render(<ResourceEditor />, document.getElementById('main'));

--- a/modules/resource-editor/ui/util/ImageLoader.js
+++ b/modules/resource-editor/ui/util/ImageLoader.js
@@ -1,0 +1,24 @@
+export default class ImageLoader {
+  constructor() {
+    this.cache = {};
+  }
+
+  load(src) {
+    if (src in this.cache) { return this.cache[src]; }
+    return (this.cache[src] = new Promise((resolve, reject) => {
+      let img = new Image();
+      let clear = () => { img = img.onload = img.onerror = null; };
+      img.src = src;
+      img.onload = (_event) => {
+        resolve({width: img.width, height: img.height});
+        clear();
+      };
+      img.onerror = (event) => {
+        reject(event);
+        clear();
+      };
+    }));
+  }
+}
+
+export let imageLoader = new ImageLoader();

--- a/modules/resource-editor/ui/util/ImageTypes.js
+++ b/modules/resource-editor/ui/util/ImageTypes.js
@@ -1,0 +1,9 @@
+let IMAGE_TYPES = {
+  '.png': true,
+  '.jpg': true,
+  '.jpeg': true,
+  '.gif': true,
+  '.bmp': true
+};
+
+export default IMAGE_TYPES;


### PR DESCRIPTION
Based on `jsio-staging` branch

To use, visit: `http://localhost:9200/apps/[route-id]/modules/resource-editor/extension/ui/`
(requires building with `devkit-plugin-builder`)

Features
 - [x] show `resources/` folders and files from http-fs mount
 - [x] enable uploading files by drag-drop to file tree
 - [ ] enable uploading files by drag-drop to folder view
 - [ ] upload confirm dialog (show list of files to-be-uploaded with previews, remove files you don't want)
 - [ ] delete file
 - [ ] move/copy file: drag and drop to file tree, dialog prompt: [copy or move?]
 - [ ] file preview thumbnail for sounds (click to play/pause sound)
 - [ ] file preview thumbnail for animations (parse filenames like timestep into animations, show single animated preview for each animation)
 - [ ] undo/redo

Future Features
 - multiple file select
 - batch-download as a zip (consider https://stuk.github.io/jszip/)
 - community art gallery for downloading files into your project
 - basic image editor: crop, rotate, resize, split